### PR TITLE
Update Documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,14 @@ TXT records from Certbot. In these cases setting the
 ``--dns-cloudns-nameserver`` option to any public nameserver (e.g. ``1.1.1.1``)
 should resolve the issue.
 
+Installation
+------------
+
+Install the plugin using ``pip``:
+
+.. code-block:: bash
+
+  pip install certbot-dns-cloudns
 
 Examples
 --------

--- a/README.rst
+++ b/README.rst
@@ -99,14 +99,14 @@ Examples
 .. code-block:: bash
 
    certbot certonly \
-     --dns-cloudns \
+     --authenticator dns-cloudns \
      --dns-cloudns-credentials ~/.secrets/certbot/cloudns.ini \
      -d example.com
 
 .. code-block:: bash
 
    certbot certonly \
-     --dns-cloudns \
+     --authenticator dns-cloudns \
      --dns-cloudns-credentials ~/.secrets/certbot/cloudns.ini \
      -d example.com \
      -d www.example.com
@@ -114,7 +114,7 @@ Examples
 .. code-block:: bash
 
    certbot certonly \
-     --dns-cloudns \
+     --authenticator dns-cloudns \
      --dns-cloudns-credentials ~/.secrets/certbot/cloudns.ini \
      --dns-cloudns-propagation-seconds 30 \
      -d example.com


### PR DESCRIPTION
Thanks for the great plugin! I'm running Certbot v1.16.0 and it looks like the way to use the plugin as the authenticator has changed at some point – it now needs to be selected using `--authenticator dns-cloudns`. I also added some basic installation instructions which may help newcomers.